### PR TITLE
add @misc to thubeamer.bst

### DIFF
--- a/thubeamer.bst
+++ b/thubeamer.bst
@@ -1827,6 +1827,35 @@ FUNCTION {article} {                              % void Entry::article() {
                                                   %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
                                                   %
+
+
+
+FUNCTION {misc}
+{ 
+  "OL" set.mark                                    %   set_mark("J");
+  start.bibitem                                   %   start_bibitem();
+  true output.title                               %   output_title(true);
+  cap.comma write$                            %   write(cap_full_stop);
+  true output.author                              %   output_author(true);
+  % true output.mark                                %   output_mark(true);
+  % true output.journal                             %   output_journal(true);
+  true output.url                                 %   output_url(true);
+  % output_year(true);
+  % false output.volume                             %   output_volume(false);
+  % false output.number                             %   output_number(false);
+  % false output.pages                              %   output_pages(false);
+  % false output.citedate                           %   output_citedate(false);
+  % false output.url.or.doi                         %   output_url_or_doi(false);
+  end.bibitem                                 %   end_bibitem();
+% bibitem.begin
+% format.authors write$ add.period
+% format.title "[OL]" * write$ add.period
+% format.year write$ add.comma
+% note write$
+% format.url
+% newline$
+}       
+
 FUNCTION {news} {                                 % void Entry::news() {
   "N" set.mark                                    %   set_mark("N");
   start.bibitem                                   %   start_bibitem();


### PR DESCRIPTION
当我用本模板写英语听说A的 presentation 的幻灯片的时候，发现一些 `@misc` 类型的参考文献不能被识别，`bibtex` 会报 `entry type for xxx isn't style-file defined` 的错误，故在 `thubeamer.bst` 文件中加入了 `FUNCTION {misc}` 函数以支持 `@misc` 类型的引用。